### PR TITLE
addressing i2c bus numbers > 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ returned from a read will be the previous value taken before sleeping.
 The arguments, are:
     * shunt_ohms: The value of the shunt resistor in Ohms (mandatory).
     * max_expected_amps: The maximum expected current in Amps (optional).
+    * busnum: The I2C bus number for the device platform, defaults to *auto detects 0 or 1 for Raspberry Pi or Beaglebone Black* (optional).
     * address: The I2C address of the INA219, defaults to *0x40* (optional).
     * log_level: Set to _logging.INFO_ to see the detailed calibration 
     calculations and _logging.DEBUG_ to see register operations (optional).

--- a/ina219.py
+++ b/ina219.py
@@ -87,7 +87,8 @@ class INA219:
     # to guarantee that current overflow can always be detected.
     __CURRENT_LSB_FACTOR = 32800
 
-    def __init__(self, shunt_ohms, max_expected_amps=None, busnum=None, address=__ADDRESS,
+    def __init__(self, shunt_ohms, max_expected_amps=None,
+                 busnum=None, address=__ADDRESS,
                  log_level=logging.ERROR):
         """ Construct the class passing in the resistance of the shunt
         resistor and the maximum expected current flowing through it in

--- a/ina219.py
+++ b/ina219.py
@@ -87,7 +87,7 @@ class INA219:
     # to guarantee that current overflow can always be detected.
     __CURRENT_LSB_FACTOR = 32800
 
-    def __init__(self, shunt_ohms, max_expected_amps=None, address=__ADDRESS,
+    def __init__(self, shunt_ohms, max_expected_amps=None, busnum=None, address=__ADDRESS,
                  log_level=logging.ERROR):
         """ Construct the class passing in the resistance of the shunt
         resistor and the maximum expected current flowing through it in
@@ -102,7 +102,7 @@ class INA219:
             calculations (optional).
         """
         logging.basicConfig(level=log_level, format=self.__LOG_FORMAT)
-        self._i2c = I2C.get_i2c_device(address)
+        self._i2c = I2C.get_i2c_device(address=address, busnum=busnum)
         self._shunt_ohms = shunt_ohms
         self._max_expected_amps = max_expected_amps
         self._min_device_current_lsb = self._calculate_min_current_lsb()


### PR DESCRIPTION
Passing busnum through to I2C to allow addressing from boards like the
UpSquared as outlined in issue #9