### PR TITLE
Logging update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 build
 dist
 pi_ina219.egg-info
+.idea/
 


### PR DESCRIPTION
Setup of root logger using `basicConfig()` is now conditional on non-existence of any other handlers.  Named module level logger is created and used instead of calls to root logger in ina219.py.  These changes should allow it to play nicer with logging in modules where it is imported at. 

Addition was also made to .gitignore for PyCharm (.idea) files.

It was tested with Python 2.7 and 3.7