### PR TITLE
Abstract i2c driver

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,12 +27,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 codecov
+        python -m pip install flake8 codecov mypy
         pip install -r tests/requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 .
+    - name: Typecheck with mypy
+      run: |
+        mypy -p ina219 --strict
     - name: Test with codecov
       run: |
         coverage run --branch --source=ina219 -m unittest discover -s tests -p 'test_*.py'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 # command to install dependencies
 install:
   - pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ python:
 # command to install dependencies
 install:
   - pip install flake8
+  - pip install mypy
   - pip install codecov
   - pip install -r tests/requirements.txt
-# check PEP8 coding standard with flake8
+# check PEP8 coding standard with flake8 and typing with mypy
 before_script:
-   flake8 .
+  - flake8 .
+  - mypy -p ina219 --strict
 # command to run tests
-script: 
+script:
   - coverage run --branch --source=ina219 -m unittest discover -s tests -p 'test_*.py'
   - coverage xml
 after_success:

--- a/example.py
+++ b/example.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python
 
 import logging
-from ina219 import INA219
+from ina219 import INA219, SmbusI2cDevice, Smbus2I2cDevice, AdafruitI2cDevice
 
 SHUNT_OHMS = 0.1
 MAX_EXPECTED_AMPS = 0.2
 
 
 def read():
-    ina = INA219(SHUNT_OHMS, MAX_EXPECTED_AMPS, log_level=logging.INFO)
+
+    i2c_addr = INA219.I2C_ADDR_DEFAULT
+
+    i2c_device = SmbusI2cDevice(interface=1, address=i2c_addr)
+    i2c_device = Smbus2I2cDevice(interface=1, address=i2c_addr)
+    i2c_device = AdafruitI2cDevice(interface=1, address=i2c_addr)
+
+    ina = INA219(i2c_device, SHUNT_OHMS, MAX_EXPECTED_AMPS,
+                 log_level=logging.INFO)
     ina.configure(ina.RANGE_16V, ina.GAIN_AUTO)
 
     print("Bus Voltage    : %.3f V" % ina.voltage())

--- a/example.py
+++ b/example.py
@@ -9,6 +9,7 @@ MAX_EXPECTED_AMPS = 0.2
 
 def read():
 
+    i2c_addr = INA219.i2c_addr()
     i2c_addr = INA219.I2C_ADDR_DEFAULT
 
     i2c_device = SmbusI2cDevice(interface=1, address=i2c_addr)

--- a/ina219.py
+++ b/ina219.py
@@ -37,6 +37,22 @@ class INA219:
 
     I2C_ADDR_DEFAULT = 0x40
 
+    class I2cAddrAx(IntEnum):
+        """Configuration values for INA219 pins A0 and A1."""
+        GND = 0b00
+        VSP = 0b01
+        SDA = 0b10
+        SCL = 0b11
+
+    @staticmethod
+    def i2c_addr(a0: I2cAddrAx = I2cAddrAx.GND,
+                 a1: I2cAddrAx = I2cAddrAx.GND) -> int:
+        """Create an I2C address from INA219 pins A0 and A1 configurations.
+
+        See "8.5.5.1 Serial Bus Address" from the datasheet.
+        """
+        return 0x40 + (a1.value << 2) + a0.value
+
     __REG_CONFIG = 0x00
     __REG_SHUNTVOLTAGE = 0x01
     __REG_BUSVOLTAGE = 0x02

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,6 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Programming Language :: Python :: 3.9',
                'Topic :: System :: Hardware :: Hardware Drivers']
 
-# Define required packages.
-requires = ['Adafruit_GPIO', 'mock']
-
 
 def read_long_description():
     try:
@@ -36,6 +33,6 @@ setup(name='pi-ina219',
       url='https://github.com/chrisb2/pi_ina219/',
       classifiers=classifiers,
       keywords='ina219 raspberrypi',
-      install_requires=requires,
+      install_requires=[],
       test_suite='tests',
       py_modules=['ina219'])

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,3 @@
-try:
-    # Try using ez_setup to install setuptools if not already installed.
-    from ez_setup import use_setuptools
-    use_setuptools()
-except ImportError:
-    # Ignore import error and assume Python 3 which already has setuptools.
-    pass
-
 from setuptools import setup
 
 DESC = ('This Python library for Raspberry Pi makes it easy to leverage the '
@@ -16,11 +8,10 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Operating System :: POSIX :: Linux',
                'License :: OSI Approved :: MIT License',
                'Intended Audience :: Developers',
-               'Programming Language :: Python :: 2.7',
-               'Programming Language :: Python :: 3.4',
-               'Programming Language :: Python :: 3.5',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7',
+               'Programming Language :: Python :: 3.8',
+               'Programming Language :: Python :: 3.9',
                'Topic :: System :: Hardware :: Hardware Drivers']
 
 # Define required packages.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,1 @@
-Adafruit_GPIO==1.0.1
 mock==2.0.0

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,8 +1,8 @@
 import sys
 import logging
 import unittest
-from mock import Mock, call, patch
-from ina219 import INA219
+from mock import Mock, call
+from ina219 import INA219, I2cDevice
 
 logger = logging.getLogger()
 logger.level = logging.ERROR
@@ -11,162 +11,167 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 
 class TestConfiguration(unittest.TestCase):
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def setUp(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.4)
-        self.ina._i2c.writeList = Mock()
+    def setUp(self):
+        I2cDevice.register(Mock)  # make "Mock" a subclass of "I2cDevice"
+        self.device = Mock()
+        self.ina = INA219(self.device, 0.1, 0.4)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_calibration_register_maximum_is_fffe_1_ohm(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(1.0, 0.01)
+    def test_calibration_register_maximum_is_fffe_1_ohm(self):
+        self.ina = INA219(self.device, 1.0, 0.01)
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
-        calls = [call(0x05, [0xFF, 0xFE]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0xFF, 0xFE])),
+                 call(0x00, bytes([0x01, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_calibration_register_maximum_is_fffe_100_mohm(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.1)
+    def test_calibration_register_maximum_is_fffe_100_mohm(self):
+        self.ina = INA219(self.device, 0.1, 0.1)
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
-        calls = [call(0x05, [0xFF, 0xFE]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0xFF, 0xFE])),
+                 call(0x00, bytes([0x01, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_calibration_register_maximum_is_fffe_10_mohm(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.01, 0.1)
+    def test_calibration_register_maximum_is_fffe_10_mohm(self):
+        self.ina = INA219(self.device, 0.01, 0.1)
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
-        calls = [call(0x05, [0xFF, 0xFE]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0xFF, 0xFE])),
+                 call(0x00, bytes([0x01, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_auto_gain_with_expected_amps(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
         self.assertEqual(self.ina._gain, 1)
         self.assertEqual(self.ina._voltage_range, 0)
         self.assertTrue(self.ina._auto_gain_enabled)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x09, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x09, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_auto_gain_no_expected_amps(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1)
+    def test_auto_gain_no_expected_amps(self):
+        self.ina = INA219(self.device, 0.1)
         self.ina._i2c.writeList = Mock()
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
         self.assertEqual(self.ina._gain, self.ina.GAIN_1_40MV)
         self.assertTrue(self.ina._auto_gain_enabled)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x01, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_manual_gain_no_expected_amps(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1)
+    def test_manual_gain_no_expected_amps(self):
+        self.ina = INA219(self.device, 0.1)
         self.ina._i2c.writeList = Mock()
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.assertEqual(self.ina._gain, self.ina.GAIN_1_40MV)
         self.assertFalse(self.ina._auto_gain_enabled)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x01, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_auto_gain_out_of_range(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 4)
+    def test_auto_gain_out_of_range(self):
+        self.ina = INA219(self.device, 0.1, 4)
         with self.assertRaisesRegexp(ValueError, "Expected amps"):
             self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_AUTO)
 
     def test_16v_40mv(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.assertEqual(self.ina._gain, 0)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x01, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x01, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_40mv(self):
         self.ina.configure(self.ina.RANGE_32V, self.ina.GAIN_1_40MV)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x21, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x21, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_80mv(self):
         self.ina.configure(self.ina.RANGE_32V, self.ina.GAIN_2_80MV)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x29, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x29, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_160mv(self):
         self.ina.configure(self.ina.RANGE_32V, self.ina.GAIN_4_160MV)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x31, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x31, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_320mv(self):
         self.ina.configure(self.ina.RANGE_32V, self.ina.GAIN_8_320MV)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x39, 0x9f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x39, 0x9f]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_40mv_9bit(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_9BIT, self.ina.ADC_9BIT)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x20, 0x07])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x20, 0x07]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_40mv_10_bit_11_bit(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_10BIT, self.ina.ADC_11BIT)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x20, 0x97])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x20, 0x97]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_40mv_2_samples_128_samples(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_2SAMP, self.ina.ADC_128SAMP)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x24, 0xff])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x24, 0xff]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_40mv_4_samples_8_samples(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_4SAMP, self.ina.ADC_8SAMP)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x25, 0x5f])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x25, 0x5f]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_40mv_8_samples_16_samples(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_8SAMP, self.ina.ADC_16SAMP)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x25, 0xe7])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x25, 0xe7]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_32v_40mv_32_samples_64_samples(self):
         self.ina.configure(
             self.ina.RANGE_32V, self.ina.GAIN_1_40MV,
             self.ina.ADC_32SAMP, self.ina.ADC_64SAMP)
-        calls = [call(0x05, [0x83, 0x33]), call(0x00, [0x26, 0xf7])]
-        self.ina._i2c.writeList.assert_has_calls(calls)
+        calls = [call(0x05, bytes([0x83, 0x33])),
+                 call(0x00, bytes([0x26, 0xf7]))]
+        self.device.write.assert_has_calls(calls)
 
     def test_invalid_voltage_range(self):
         with self.assertRaisesRegexp(ValueError, "Invalid voltage range"):
             self.ina.configure(64, self.ina.GAIN_1_40MV)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_max_current_exceeded(self, device):
-        device.return_value = Mock()
-        ina = INA219(0.1, 0.5)
+    def test_max_current_exceeded(self):
+        ina = INA219(self.device, 0.1, 0.5)
         with self.assertRaisesRegexp(ValueError, "Expected current"):
-            ina.configure(ina.RANGE_32V, ina.GAIN_1_40MV)
+            ina.configure(self.ina.RANGE_32V, ina.GAIN_1_40MV)
 
     def test_sleep(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0xf)
+        self.device.read_word.return_value = 0x0F
         self.ina.sleep()
-        self.ina._i2c.writeList.assert_called_with(0x00, [0x00, 0x08])
+        self.device.write.assert_called_with(
+            0x00, bytes([0x00, 0x08]))
 
     def test_wake(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0x8)
+        self.device.read_word.return_value = 0x08
         self.ina.wake()
-        self.ina._i2c.writeList.assert_called_with(0x00, [0x00, 0xf])
+        self.device.write.assert_called_with(
+            0x00, bytes([0x00, 0xf]))
 
     def test_reset(self):
         self.ina.reset()
-        self.ina._i2c.writeList.assert_called_with(0x00, [0x80, 0x00])
+        self.device.write.assert_called_with(
+            0x00, bytes([0x80, 0x00]))

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -1,8 +1,8 @@
 import sys
 import logging
 import unittest
-from mock import Mock, patch
-from ina219 import INA219
+from mock import Mock
+from ina219 import INA219, I2cDevice
 
 logger = logging.getLogger()
 logger.level = logging.ERROR
@@ -11,19 +11,25 @@ logger.addHandler(logging.StreamHandler(sys.stdout))
 
 class TestConstructor(unittest.TestCase):
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_default(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1)
+    def setUp(self):
+        I2cDevice.register(Mock)  # make "Mock" a subclass of "I2cDevice"
+        self.device = Mock()
+
+    def test_default(self):
+        self.ina = INA219(self.device, 0.1)
         self.assertEqual(self.ina._shunt_ohms, 0.1)
         self.assertIsNone(self.ina._max_expected_amps)
         self.assertIsNone(self.ina._gain)
         self.assertFalse(self.ina._auto_gain_enabled)
         self.assertAlmostEqual(self.ina._min_device_current_lsb, 6.25e-6, 2)
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def test_with_max_expected_amps(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.4)
+    def test_with_max_expected_amps(self):
+        self.ina = INA219(self.device, 0.1, 0.4)
         self.assertEqual(self.ina._shunt_ohms, 0.1)
         self.assertEqual(self.ina._max_expected_amps, 0.4)
+
+    def test_with_invalid_i2c_device_class(self):
+        non_i2c_driver_instance = object()
+        exp_exc_msg = 'I2C device class must be a subclass of I2cDevice'
+        with self.assertRaisesRegexp(AssertionError, exp_exc_msg):
+            self.ina = INA219(non_i2c_driver_instance, 0)

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -1,8 +1,8 @@
 import sys
 import logging
 import unittest
-from mock import Mock, patch
-from ina219 import INA219
+from mock import Mock
+from ina219 import INA219, I2cDevice
 from ina219 import DeviceRangeError
 
 
@@ -15,26 +15,25 @@ class TestRead(unittest.TestCase):
 
     GAIN_RANGE_MSG = r"Current out of range \(overflow\)"
 
-    @patch('Adafruit_GPIO.I2C.get_i2c_device')
-    def setUp(self, device):
-        device.return_value = Mock()
-        self.ina = INA219(0.1, 0.4)
-        self.ina._i2c.writeList = Mock()
+    def setUp(self):
+        I2cDevice.register(Mock)  # make "Mock" a subclass of "I2cDevice"
+        self.device = Mock()
+        self.ina = INA219(self.device, 0.1, 0.4)
 
     def test_read_32v(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0xfa00)
+        self.device.read_word.return_value = 0xfa00
         self.assertEqual(self.ina.voltage(), 32)
 
     def test_read_16v(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0x7d00)
+        self.device.read_word.return_value = 0x7d00
         self.assertEqual(self.ina.voltage(), 16)
 
     def test_read_4_808v(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0x2592)
+        self.device.read_word.return_value = 0x2592
         self.assertEqual(self.ina.voltage(), 4.808)
 
     def test_read_4mv(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0x8)
+        self.device.read_word.return_value = 0x8
         self.assertEqual(self.ina.voltage(), 0.004)
 
     def test_read_supply_voltage(self):
@@ -43,73 +42,73 @@ class TestRead(unittest.TestCase):
         self.assertEqual(self.ina.supply_voltage(), 2.539)
 
     def test_read_0v(self):
-        self.ina._i2c.readU16BE = Mock(return_value=0)
+        self.device.read_word.return_value = 0
         self.assertEqual(self.ina.voltage(), 0)
 
     def test_read_12ua(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=0x1)
+        self.device.read_word.return_value = 0x1
         self.assertAlmostEqual(self.ina.current(), 0.012, 3)
 
     def test_read_0ma(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=0)
+        self.device.read_word.return_value = 0
         self.assertEqual(self.ina.current(), 0)
 
     def test_read_negative_ma(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=-0x4d52)
+        self.device.read_word.return_value = -0x4d52
         self.assertAlmostEqual(self.ina.current(), -241.4, 1)
 
     def test_read_0mw(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0)
+        self.device.read_word.return_value = 0
         self.assertEqual(self.ina.power(), 0)
 
     def test_read_1914mw(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readU16BE = Mock(return_value=0x1ea9)
+        self.device.read_word.return_value = 0x1ea9
         self.assertAlmostEqual(self.ina.power(), 1914.0, 0)
 
     def test_read_shunt_20mv(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=0x7d0)
+        self.device.read_word.return_value = 0x7d0
         self.assertEqual(self.ina.shunt_voltage(), 20.0)
 
     def test_read_shunt_0mv(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=0)
+        self.device.read_word.return_value = 0
         self.assertEqual(self.ina.shunt_voltage(), 0)
 
     def test_read_shunt_negative_40mv(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_1_40MV)
         self.ina._read_voltage_register = Mock(return_value=0xfa0)
-        self.ina._i2c.readS16BE = Mock(return_value=-0xfa0)
+        self.device.read_word.return_value = -0xfa0
         self.assertEqual(self.ina.shunt_voltage(), -40.0)
 
     def test_current_overflow_valid(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0xfa1)
+        self.device.read_word.return_value = 0xfa1
         self.assertTrue(self.ina.current_overflow())
 
     def test_current_overflow_error(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0xfa1)
+        self.device.read_word.return_value = 0xfa1
         with self.assertRaisesRegexp(DeviceRangeError, self.GAIN_RANGE_MSG):
             self.ina.current()
 
     def test_new_read_available(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0xA)
+        self.device.read_word.return_value = 0xA
         self.assertTrue(self.ina.is_conversion_ready())
 
     def test_new_read_not_available(self):
         self.ina.configure(self.ina.RANGE_16V, self.ina.GAIN_2_80MV)
-        self.ina._i2c.readU16BE = Mock(return_value=0x8)
+        self.device.read_word.return_value = 0x8
         self.assertFalse(self.ina.is_conversion_ready())


### PR DESCRIPTION
@chrisb2  here is the suggested abstraction of the I2C drivers.

The PR targets `master`, though it builds up on my other branch `add-type-hints` (https://github.com/chrisb2/pi_ina219/pull/29). Not sure how to change this on GitHub.

This change would make your branch `convert-to-smbus2` obsolete.

I'm also removing the `install_requires` from `setup.py`, because testing packages aren't needed for installation.

To be discussed would be, what the best location for the example/reference implementations of I2C devices (`AdafruitI2cDevice`, `SmbusI2cDevice`, and `SmbusI2cDevice`) could be. For now, I just put them into the same module. But the `import` statements within the constructors are a bit debatable - not a problem for example code I'd say, but not so nice in the delivered module. Speaking of which - perhaps `examples.py` wouldn't be such a bad place for those.